### PR TITLE
Bugfix creating mirrors

### DIFF
--- a/bin/actions/uploader.js
+++ b/bin/actions/uploader.js
@@ -324,7 +324,6 @@ Uploader.prototype._mirror = function(fileid) {
     'Establishing %s mirrors per shard for redundancy',
     [this.redundancy]
   );
-  log('info', 'This can take a while, so grab a cocktail...');
 
   this.client.replicateFileFromBucket(
     this.bucket,

--- a/bin/actions/uploader.js
+++ b/bin/actions/uploader.js
@@ -342,7 +342,6 @@ Uploader.prototype._mirror = function(fileid) {
         ]);
       });
 
-      process.exit();
     }
   );
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     {
       "name": "Gordon Hall",
       "url": "gordonwritescode.com"
+    },
+    {
+      "name": "littleskunk",
+      "url": "https://github.com/littleskunk"
     }
   ],
   "license": "(LGPL-3.0)",


### PR DESCRIPTION
Nobody can grab a cocktail in less than one second. Creating mirrors is very fast.

The process.exit stops the upload process even if the user would like to upload more than one file.