### PR TITLE
Fix stripISOString

### DIFF
--- a/bin/actions/downloader.js
+++ b/bin/actions/downloader.js
@@ -70,15 +70,8 @@ Downloader.prototype._validate = function() {
  * @private
  */
 Downloader.prototype._stripISOString = function(fileName){
-  var array = fileName.split(' ');
-  var potentialDate = array[0];
-  var re = /\(\d{4}-\d{2}-\d{2}T\d{2};\d{2};\d{2}.\d{3}Z\)-/g;
-  var isValid = potentialDate.match(re);
-  if (isValid){
-    return array.splice(1).join(' ');
-  } else {
-    return fileName;
-  }
+  var re = /^\(\d{4}-\d{2}-\d{2}T\d{2};\d{2};\d{2}.\d{3}Z\)-/g;
+  return fileName.replace(re, '');
 };
 
 /**


### PR DESCRIPTION
This makes it work with the new file naming (which doesn't include spaces) method and simplifies the function.