### PR TITLE
WIP Enhancement/fix: force prompt for keyring pass on upload

### DIFF
--- a/bin/actions/uploader.js
+++ b/bin/actions/uploader.js
@@ -14,7 +14,6 @@ var monitor = require('os-monitor');
  * @constructor
  * @license AGPL-3.0
  * @param {BridgeClient} client - Authenticated Bridge Client with Storj API.
- * @param {String} keypass - Password for unlocking keyring.
  * @param {Number} options.env.concurrency - shard upload concurrency.
  * @param {Number} options.env.fileconcurrency - File upload concurrency.
  * @param {String} options.bucket - Bucket files are uploaded to.
@@ -37,7 +36,7 @@ function Uploader(client, bucket, options) {
       requestTimeout: 10000
     }
   );
-  this.keypass = options.keypass;
+  this.keypass = null;
   this.filepaths = this._getAllFiles(options.filepath);
   this.fileCount = this.filepaths.length;
   this.uploadedCount = 0;

--- a/bin/storj.js
+++ b/bin/storj.js
@@ -34,7 +34,6 @@ program.version(
 );
 program.option('-u, --url <url>', 'set the base url for the api');
 program.option('-n, --byname', 'treat ids as names');
-program.option('-k, --keypass <password>', 'unlock keyring without prompt');
 program.option('-d, --debug', 'display debug data', 4);
 
 program._storj.loglevel = function() {
@@ -133,7 +132,7 @@ var ACTIONS = {
     bucket = program._storj.getRealBucketId(bucket, env.user);
     var options = {
       filepath: filepath,
-      keypass: program._storj.getKeyPass(),
+      keypass: null,
       env: env
     };
     var uploader;
@@ -244,6 +243,7 @@ program
 program
   .command('remove-bucket <bucket-id>')
   .option('-f, --force', 'skip confirmation prompt')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('destroys a specific storage bucket')
   .action(actions.buckets.remove.bind(program));
 
@@ -256,6 +256,7 @@ program
   .command('make-public <bucket-id>')
   .option('--pull', 'make PULL operations public')
   .option('--push', 'make PUSH operations public')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('makes a specific storage bucket public, ' +
     'uploading bucket key to bridge')
   .action(actions.buckets.makePublic.bind(program));
@@ -283,6 +284,7 @@ program
 
 program
   .command('export-keyring <directory>')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('compresses and exports keyring to specific directory')
   .action(utils.exportkeyring.bind(program));
 
@@ -309,6 +311,7 @@ program
 program
   .command('remove-file <bucket-id> <file-id>')
   .option('-f, --force', 'skip confirmation prompt')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('delete a file pointer from a specific bucket')
   .action(actions.files.remove.bind(program));
 
@@ -324,6 +327,7 @@ program
   .command('download-file <bucket-id> <file-id> <filepath>')
   .option('-x, --exclude <nodeID,nodeID...>', 'mirrors to create for file', '')
   .option('-u, --user <user>', 'user id for public name resolution', null)
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('download a file from the network with a pointer from a bucket')
   .action(ACTIONS.download);
 
@@ -369,13 +373,15 @@ program
 
 program
   .command('change-keyring')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('change the keyring password')
   .action(utils.changekeyring.bind(program));
 
-  program
-    .command('reset-keyring')
-    .description('delete the current keyring and start a new one')
-    .action(utils.resetkeyring.bind(program));
+program
+  .command('reset-keyring')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
+  .description('delete the current keyring and start a new one')
+  .action(utils.resetkeyring.bind(program));
 
 program
   .command('sign-message <privatekey> <message>')
@@ -386,6 +392,7 @@ program
 program
   .command('stream-file <bucket-id> <file-id>')
   .option('-x, --exclude <nodeID,nodeID...>', 'mirrors to create for file', '')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('stream a file from the network and write to stdout')
   .action(actions.files.stream.bind(program));
 
@@ -396,21 +403,25 @@ program
 
 program
   .command('generate-seed')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('generates new deterministic seed')
   .action(actions.seed.generateSeed.bind(program));
 
 program
   .command('print-seed')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('prints the human readable deterministic seed')
   .action(actions.seed.printSeed.bind(program));
 
 program
   .command('import-seed')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('imports deterministic seed from another device')
   .action(actions.seed.importSeed.bind(program));
 
 program
   .command('delete-seed')
+  .option('-k, --keypass <password>', 'unlock keyring without prompt')
   .description('deletes the deterministic seed from the keyring')
   .action(actions.seed.deleteSeed.bind(program));
 

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -91,7 +91,7 @@ module.exports.getKeyRing = function(keypass, callback) {
     return callback(keyring);
   }
 
-  var description = storj.utils.existsSync(DATADIR) ?
+  var description = storj.utils.existsSync(path.join(DATADIR, 'key.ring')) ?
                     'Enter your passphrase to unlock your keyring' :
                     'Enter a passphrase to protect your keyring';
 

--- a/test/actions/uploader.unit.js
+++ b/test/actions/uploader.unit.js
@@ -90,7 +90,7 @@ describe('uploader', function() {
         transferConcurrency: testOptions.env.concurrency,
         requestTimeout: 10000
       })).to.equal(true);
-      expect(uploader.keypass).to.equal(testOptions.keypass);
+      expect(uploader.keypass).to.equal(null);
       expect(uploader.filepaths).to.equal(testFiles);
       expect(uploader.fileCount).to.equal(testFiles.length);
       expect(uploader.uploadedCount).to.equal(0);


### PR DESCRIPTION
In reference to https://github.com/Storj/core-cli/issues/29

The PR assumes The default behavior of ``storj upload-file <bucketid> <file-path>`` should be to have a ``null`` keypass so that ``utils.getKeyRing(keypass, () -> {...})`` prompts the user to 'Enter your passphrase to unlock your keyring' if ``OS/.storjcli/key.ring`` exists, otherwise 'Enter a passphrase to protect your keyring'. Discussion should follow if this is a good idea. This will also limit the ability to set the env var ``STORJ_KEYPASS`` on uploads.

If we simply removed https://github.com/Storj/core-cli/blob/master/bin/storj.js#L136 we could effectively accomplish this but Commander won't trigger its internal error messages.

Perhaps a better approach as is implemented in this PR is to refactor ``ACTIONS.upload()`` to not take a keypass option so that it passes in to ``getKeyRing`` as ``null`` and prompts the user. Then move the Commander option on ``Storj -k``

 ``program.option('-k, --keypass <password>', 'unlock keyring without prompt');``

to the more specific commands that could take a keypass option for decryption like ``storj download-file``

```
program
  .command('download-file <bucket-id> <file-id> <filepath>')
  .option('-x, --exclude <nodeID,nodeID...>', 'mirrors to create for file', '')
  .option('-u, --user <user>', 'user id for public name resolution', null)
  .option('-k, --keypass <password>', 'unlock keyring without prompt')
  .description('download a file from the network with a pointer from a bucket')
  .action(ACTIONS.download);
```

Let me know if there is something I am missing or if there are other commands that should take the -k option (seed, destroy-file, buckets).
